### PR TITLE
Update Ocelot to latest version

### DIFF
--- a/src/MMLib.Ocelot.Provider.AppConfiguration/MMLib.Ocelot.Provider.AppConfiguration.csproj
+++ b/src/MMLib.Ocelot.Provider.AppConfiguration/MMLib.Ocelot.Provider.AppConfiguration.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>4.0.0</Version>
     <Authors>Milan Martiniak</Authors>
     <Company>MMLib</Company>
     <Description>App configuration provider for obtaining services.</Description>
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ocelot" Version="20.0.0" />
+    <PackageReference Include="Ocelot" Version="23.4.3" />
   </ItemGroup>
 
 </Project>

--- a/tests/MMLib.Ocelot.Provider.AppConfiguration.Tests/MMLib.Ocelot.Provider.AppConfiguration.Tests.csproj
+++ b/tests/MMLib.Ocelot.Provider.AppConfiguration.Tests/MMLib.Ocelot.Provider.AppConfiguration.Tests.csproj
@@ -1,21 +1,21 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="FluentAssertions" Version="8.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Old Ocelot does not support streaming. If big request is routed thorugh Ocelot, it will load all data from downstream into memory and then send it to client. This was [fixed](https://github.com/ThreeMammals/Ocelot/pull/1961) in [Ocelot 23](https://github.com/ThreeMammals/Ocelot/pull/1961).